### PR TITLE
Update macOS deployment target to 14.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -157,7 +157,7 @@ jobs:
       
       - name: 🏗️ Build App Bundle
         run: |
-          ./build_app.sh release
+          ./build_app_unified.sh release
           echo "✅ App bundle created"
       
       - name: 📦 Create Release Assets
@@ -213,7 +213,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       
       - name: 🐙 Create GitHub Release
-        uses: ncipollo/create-release@v1
+        uses: ncipollo/create-release@v1.14.0
         with:
           tag: ${{ github.ref_name }}
           name: "${{ env.APP_NAME }} ${{ env.BETA_VERSION }}"
@@ -404,7 +404,7 @@ jobs:
       
       - name: 🏗️ Build App Bundle
         run: |
-          ./build_app.sh release
+          ./build_app_unified.sh release
           echo "✅ App bundle created"
       
       - name: 📦 Create Release Assets
@@ -459,7 +459,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       
       - name: 🐙 Create GitHub Release
-        uses: ncipollo/create-release@v1
+        uses: ncipollo/create-release@v1.14.0
         with:
           tag: ${{ github.ref_name }}
           name: "${{ env.APP_NAME }} v${{ env.VERSION }}"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,7 @@ env:
   BUNDLE_ID: com.jsonify.clickit
   
   # macOS deployment target
-  MACOSX_DEPLOYMENT_TARGET: "15.0"
+  MACOSX_DEPLOYMENT_TARGET: "14.0"
   
   # Swift configuration
   SWIFT_VERSION: "6.1"
@@ -206,7 +206,7 @@ jobs:
           fi
           
           CHANGELOG="⚠️ **This is a beta release for testing purposes.**\n\n${CHANGELOG}"
-          CHANGELOG="${CHANGELOG}\n\n---\n🤖 Generated with [Claude Code](https://claude.ai/code)\n📱 Compatible with macOS 15.0 or later"
+          CHANGELOG="${CHANGELOG}\n\n---\n🤖 Generated with [Claude Code](https://claude.ai/code)\n📱 Compatible with macOS 14.0 or later"
           
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo -e "$CHANGELOG" >> $GITHUB_OUTPUT
@@ -320,7 +320,7 @@ jobs:
                       <link>\(release.htmlUrl)</link>
                       <sparkle:version>\(version)</sparkle:version>
                       <sparkle:shortVersionString>\(version)</sparkle:shortVersionString>
-                      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+                      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
                       <pubDate>\(pubDate)</pubDate>
                       <enclosure url="\(zipAsset.browserDownloadUrl)" 
                                  length="\(zipAsset.size)" 
@@ -452,7 +452,7 @@ jobs:
             done
           fi
           
-          CHANGELOG="${CHANGELOG}\n\n---\n🤖 Generated with [Claude Code](https://claude.ai/code)\n📱 Compatible with macOS 15.0 or later"
+          CHANGELOG="${CHANGELOG}\n\n---\n🤖 Generated with [Claude Code](https://claude.ai/code)\n📱 Compatible with macOS 14.0 or later"
           
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo -e "$CHANGELOG" >> $GITHUB_OUTPUT
@@ -559,7 +559,7 @@ jobs:
                       <link>\(release.htmlUrl)</link>
                       <sparkle:version>\(version)</sparkle:version>
                       <sparkle:shortVersionString>\(version)</sparkle:shortVersionString>
-                      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+                      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
                       <pubDate>\(pubDate)</pubDate>
                       <enclosure url="\(zipAsset.browserDownloadUrl)" 
                                  length="\(zipAsset.size)" 
@@ -723,7 +723,7 @@ jobs:
                       <link>\(release.htmlUrl)</link>
                       <sparkle:version>\(version)</sparkle:version>
                       <sparkle:shortVersionString>\(version)</sparkle:shortVersionString>
-                      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+                      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
                       <pubDate>\(pubDate)</pubDate>
                       <enclosure url="\(zipAsset.browserDownloadUrl)" 
                                  length="\(zipAsset.size)" 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-and-release:
     name: 🔨 Build Universal App & Create Release
-    runs-on: macos-latest
+    runs-on: macos-15
     
     steps:
     - name: 📥 Checkout Code
@@ -52,6 +52,11 @@ jobs:
     - name: 🏗️ Build Universal App with Xcode
       run: |
         echo "🔨 Building ${{ env.APP_NAME }} with Xcode..."
+        # Set environment variables for CI build (disable code signing, fix deployment target)
+        export CODE_SIGN_IDENTITY=""
+        export CODE_SIGNING_REQUIRED=NO
+        export CODE_SIGNING_ALLOWED=NO
+        export MACOSX_DEPLOYMENT_TARGET=14.0
         ./build_app_unified.sh release xcode
         
         echo "📦 Creating release archive..."
@@ -110,7 +115,7 @@ jobs:
         echo "- 🔄 **Auto-Updates**: Built-in Sparkle framework integration" >> release_notes.md
         echo "" >> release_notes.md
         echo "## 📋 System Requirements" >> release_notes.md
-        echo "- **macOS**: 15.0 or later" >> release_notes.md
+        echo "- **macOS**: 14.0 or later" >> release_notes.md
         echo "- **Architecture**: Universal Binary (Intel x64 + Apple Silicon)" >> release_notes.md
         echo "- **Permissions**: Accessibility and Screen Recording access required" >> release_notes.md
         echo "" >> release_notes.md
@@ -135,7 +140,7 @@ jobs:
         echo "🏗️ **Built with**: Xcode on GitHub Actions" >> release_notes.md
         echo "📅 **Build Date**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> release_notes.md
         echo "🔖 **Version**: ${VERSION}" >> release_notes.md
-        echo "🎯 **Target**: macOS 15.0+" >> release_notes.md
+        echo "🎯 **Target**: macOS 14.0+" >> release_notes.md
         
         echo "release_notes_file=release_notes.md" >> $GITHUB_OUTPUT
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,6 @@ jobs:
         body_path: release_notes.md
         draft: false
         prerelease: false
-        make_latest: true
         files: |
           dist/${{ env.APP_NAME }}.app.zip
           dist/build-info.txt

--- a/ClickIt/Info.plist
+++ b/ClickIt/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSMinimumSystemVersion</key>
-    <string>15.0</string>
+    <string>14.0</string>
     <key>LSUIElement</key>
     <false/>
     <key>NSHighResolutionCapable</key>

--- a/build_app_unified.sh
+++ b/build_app_unified.sh
@@ -219,7 +219,7 @@ else
     <key>CFBundleVersion</key>
     <string>$BUILD_NUMBER</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>${MACOSX_DEPLOYMENT_TARGET:-14.0}</string>
     <key>LSUIElement</key>
     <false/>
     <key>NSHighResolutionCapable</key>

--- a/build_app_unified.sh
+++ b/build_app_unified.sh
@@ -219,7 +219,7 @@ else
     <key>CFBundleVersion</key>
     <string>$BUILD_NUMBER</string>
     <key>LSMinimumSystemVersion</key>
-    <string>15.0</string>
+    <string>14.0</string>
     <key>LSUIElement</key>
     <false/>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
Adjust the macOS deployment target across CI/CD workflows and build scripts to ensure compatibility with earlier versions.