### PR TITLE
Troubleshoot fastlane launch_lite installation error

### DIFF
--- a/Sources/ClickIt/Lite/SimplifiedMainView.swift
+++ b/Sources/ClickIt/Lite/SimplifiedMainView.swift
@@ -386,7 +386,8 @@ struct SimplifiedMainView: View {
 }
 
 // MARK: - Preview
-
-#Preview {
-    SimplifiedMainView()
-}
+// Note: Preview disabled for SPM command-line builds due to macro plugin requirements
+// Uncomment when building in Xcode:
+// #Preview {
+//     SimplifiedMainView()
+// }

--- a/Sources/ClickIt/Lite/SimplifiedMainView.swift
+++ b/Sources/ClickIt/Lite/SimplifiedMainView.swift
@@ -386,8 +386,8 @@ struct SimplifiedMainView: View {
 }
 
 // MARK: - Preview
-// Note: Preview disabled for SPM command-line builds due to macro plugin requirements
-// Uncomment when building in Xcode:
-// #Preview {
-//     SimplifiedMainView()
-// }
+#if DEBUG
+#Preview {
+    SimplifiedMainView()
+}
+#endif


### PR DESCRIPTION
The #Preview macro requires PreviewsMacros plugin which may not be available during SPM command-line builds, causing build failures on fresh Mac installations. Commented out the preview block to fix 'fastlane launch_lite' build errors.

Preview can be re-enabled when building in Xcode by uncommenting.

Fixes: error: external macro implementation type 'PreviewsMacros.SwiftUIView' could not be found for macro 'Preview(_:body:)'