### PR TITLE
ci: note PAT scope requirements in auto-release comment

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,5 +1,5 @@
 # Auto Patch Release
-# Triggered when a pull request is merged into main.
+# Triggered when a pull request is merged into main. (PAT scope: workflow + Actions)
 # Bumps the patch version, updates Info.plist, commits, then pushes a v* tag
 # which triggers the full release pipeline in cicd.yml.
 #


### PR DESCRIPTION
## Summary
- Trivial comment update to `auto-release.yml` to test the full auto-release flow with updated PAT permissions (workflow + Actions read/write)

## Test plan
- [ ] Merge this PR
- [ ] `auto-release.yml` fires and bumps `v1.6.1` → `v1.6.2`
- [ ] `cicd.yml` triggers from the new tag (this is the real test — previously it didn't fire)
- [ ] GitHub Release `v1.6.2` appears in Releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)