### PR TITLE
ci: dispatch cicd.yml directly after tag push

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -110,4 +110,14 @@ jobs:
           git tag "$TAG"
           git push origin main
           git push origin "$TAG"
-          echo "✅ Pushed tag $TAG — cicd.yml release pipeline should now trigger"
+          echo "✅ Pushed tag $TAG"
+
+      - name: 🎬 Trigger release pipeline
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          TAG="v${{ steps.next_version.outputs.next }}"
+          echo "Dispatching cicd.yml for $TAG..."
+          gh workflow run cicd.yml --ref "$TAG"
+          echo "✅ cicd.yml dispatched for $TAG"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,6 +8,12 @@ name: Release Pipeline
 on:
   push:
     tags: [ 'v*', 'beta*' ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.6.1)'
+        required: true
+        type: string
 
 # Prevent overlapping release builds
 concurrency:


### PR DESCRIPTION
## Summary
- Cross-workflow triggering via tag push has been unreliable (cicd.yml not firing for v1.6.1, v1.6.2)
- Fixes root cause: after pushing the tag, explicitly dispatch `cicd.yml` via `gh workflow run cicd.yml --ref TAG`
- Adds `workflow_dispatch` trigger to `cicd.yml` to support this
- No change to existing tag-push trigger (still works for manual tag pushes)

## Test plan
- [ ] Merge this PR — auto-release should bump to `v1.6.3`
- [ ] `cicd.yml` should be dispatched directly and create the GitHub Release
- [ ] No manual intervention needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)