### PR TITLE
fix(ci): make workflow_dispatch tag input optional

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       tag:
         description: 'Tag to release (e.g. v1.6.1)'
-        required: true
+        required: false
         type: string
 
 # Prevent overlapping release builds


### PR DESCRIPTION
## Summary
- Fixes HTTP 422 error in auto-release pipeline dispatch step
- `cicd.yml` had `required: true` on the `tag` workflow_dispatch input, but `auto-release.yml` calls `gh workflow run cicd.yml --ref "$TAG"` without passing `-f tag=`
- The `tag` input is unused in `cicd.yml` logic (version is extracted from `github.ref_name`), so `required: false` is safe

## Test plan
- [ ] Merge this PR → auto-release workflow triggers on merge
- [ ] Auto-release bumps patch version (should go to v1.6.4)
- [ ] `cicd.yml` is dispatched successfully (no 422 error)
- [ ] GitHub Release v1.6.4 is created with .dmg artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)