### PR TITLE
Feat/timing diagnostic screen

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,8 @@ let package = Package(
                 "SimplePermissionManager.swift",
                 "SimpleViewModel.swift",
                 "SimplifiedMainView.swift",
-                "Resources"
+                "Resources",
+                "TimingDiagnostic"
             ]
         ),
         .testTarget(

--- a/Sources/ClickIt/Lite/LiteScheduler.swift
+++ b/Sources/ClickIt/Lite/LiteScheduler.swift
@@ -55,6 +55,8 @@ final class LiteScheduler {
     var countdownUpdateHandler: ((TimeInterval) -> Void)?
     /// Called once immediately after the scheduled task executes.
     var executionHandler: (() -> Void)?
+    /// Called once with a `TimingRecord` after each firing. Delivered on the main queue.
+    var onTimingRecord: ((TimingRecord) -> Void)?
 
     // MARK: - Initialization
 
@@ -185,18 +187,26 @@ final class LiteScheduler {
     }
 
     private func executeTask() {
-        logger.info("LiteScheduler: executing task at \(Date())")
+        // Capture actualAt first — before any other work — for maximum timing accuracy.
+        let actualAt = Date()
+        logger.info("LiteScheduler: executing task at \(actualAt)")
         finalCountdownTimer?.cancel()
         finalCountdownTimer = nil
 
         let task = scheduledTask
         let handler = executionHandler
+        let timingCallback = onTimingRecord
+        let scheduledAt = targetDate
         scheduledTask = nil
         targetDate = nil
 
         DispatchQueue.main.async {
             task?()
             handler?()
+            if let scheduledAt, let timingCallback {
+                let record = TimingRecord(scheduledAt: scheduledAt, actualAt: actualAt)
+                timingCallback(record)
+            }
         }
     }
 

--- a/Sources/ClickIt/Lite/ScheduledClickManager.swift
+++ b/Sources/ClickIt/Lite/ScheduledClickManager.swift
@@ -44,6 +44,11 @@ final class ScheduledClickManager: ObservableObject {
 
     /// Called immediately after the scheduled click fires, before state resets to idle.
     var executionHandler: (() -> Void)?
+    /// Called once per firing with a timing accuracy record. Forwarded from `LiteScheduler`.
+    var onTimingRecord: ((TimingRecord) -> Void)? {
+        get { scheduler.onTimingRecord }
+        set { scheduler.onTimingRecord = newValue }
+    }
 
     // MARK: - Initialization
 

--- a/Sources/ClickIt/Lite/SimpleViewModel.swift
+++ b/Sources/ClickIt/Lite/SimpleViewModel.swift
@@ -42,24 +42,25 @@ final class SimpleViewModel: ObservableObject {
     private let clickEngine = SimpleClickEngine()
     private let hotkeyManager = SimpleHotkeyManager.shared
     private let permissionManager = SimplePermissionManager.shared
-    private let scheduledClickManager = ScheduledClickManager()
+    private let scheduledClickManager: ScheduledClickManager
 
     // MARK: - Initialization
 
-    init() {
+    init(scheduledClickManager: ScheduledClickManager? = nil) {
+        self.scheduledClickManager = scheduledClickManager ?? ScheduledClickManager()
         // Set up emergency stop handler (already on MainActor)
         hotkeyManager.startMonitoring { [weak self] in
             self?.stopClicking()
         }
         // Mirror scheduler state and countdown into our published properties
-        scheduledClickManager.$state.assign(to: &$schedulerState)
-        scheduledClickManager.$countdown.assign(to: &$schedulerCountdown)
+        self.scheduledClickManager.$state.assign(to: &$schedulerState)
+        self.scheduledClickManager.$countdown.assign(to: &$schedulerCountdown)
         // Update status message when scheduled click fires
-        scheduledClickManager.executionHandler = { [weak self] in
+        self.scheduledClickManager.executionHandler = { [weak self] in
             self?.statusMessage = "Scheduled click fired!"
         }
         // Wire timing records into the diagnostic session
-        scheduledClickManager.onTimingRecord = { [weak self] record in
+        self.scheduledClickManager.onTimingRecord = { [weak self] record in
             self?.diagnosticSession.add(record)
         }
     }

--- a/Sources/ClickIt/Lite/SimpleViewModel.swift
+++ b/Sources/ClickIt/Lite/SimpleViewModel.swift
@@ -32,6 +32,11 @@ final class SimpleViewModel: ObservableObject {
     @Published private(set) var schedulerState: ScheduledClickManager.State = .idle
     @Published private(set) var schedulerCountdown: TimeInterval = 0
 
+    // MARK: - Public Properties
+
+    /// Session-scoped timing accuracy data. Populated passively each time a scheduled click fires.
+    let diagnosticSession = DiagnosticSession()
+
     // MARK: - Private Properties
 
     private let clickEngine = SimpleClickEngine()
@@ -52,6 +57,10 @@ final class SimpleViewModel: ObservableObject {
         // Update status message when scheduled click fires
         scheduledClickManager.executionHandler = { [weak self] in
             self?.statusMessage = "Scheduled click fired!"
+        }
+        // Wire timing records into the diagnostic session
+        scheduledClickManager.onTimingRecord = { [weak self] record in
+            self?.diagnosticSession.add(record)
         }
     }
 

--- a/Sources/ClickIt/Lite/SimplifiedMainView.swift
+++ b/Sources/ClickIt/Lite/SimplifiedMainView.swift
@@ -54,50 +54,66 @@ package struct SimplifiedMainView: View {
     // MARK: - Body
 
     package var body: some View {
-        VStack(spacing: 20) {
-            // Title
-            Text("ClickIt Lite")
-                .font(.title)
-                .fontWeight(.bold)
+        TabView {
+            mainTab
+                .tabItem {
+                    Label("Clicker", systemImage: "cursorarrow.click.2")
+                }
 
-            Divider()
-
-            // Permission check
-            if !permissionManager.hasAccessibilityPermission {
-                permissionSection
-            }
-
-            // Coordinate Mode
-            coordinateModeSection
-
-            // Click Location
-            clickLocationSection
-
-            // Click Interval
-            clickIntervalSection
-
-            // Click Type
-            clickTypeSection
-
-            Divider()
-
-            // Scheduler
-            schedulerSection
-
-            Spacer()
-
-            // Start/Stop Button
-            startStopButton
-
-            // Status
-            statusSection
-
-            Spacer()
+            DiagnosticTabView(session: viewModel.diagnosticSession)
+                .tabItem {
+                    Label("Diagnostics", systemImage: "waveform.path.ecg")
+                }
         }
-        .padding(30)
-        .frame(width: 400, height: 720)
+        .frame(width: 420, height: 760)
         .onAppear {
             permissionManager.checkPermissions()
+        }
+    }
+
+    private var mainTab: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Title
+                Text("ClickIt Lite")
+                    .font(.title)
+                    .fontWeight(.bold)
+
+                Divider()
+
+                // Permission check
+                if !permissionManager.hasAccessibilityPermission {
+                    permissionSection
+                }
+
+                // Coordinate Mode
+                coordinateModeSection
+
+                // Click Location
+                clickLocationSection
+
+                // Click Interval
+                clickIntervalSection
+
+                // Click Type
+                clickTypeSection
+
+                Divider()
+
+                // Scheduler
+                schedulerSection
+
+                Spacer()
+
+                // Start/Stop Button
+                startStopButton
+
+                // Status
+                statusSection
+
+                Spacer()
+            }
+            .padding(30)
         }
     }
 

--- a/Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticSession.swift
+++ b/Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticSession.swift
@@ -1,0 +1,103 @@
+//
+//  DiagnosticSession.swift
+//  ClickIt Lite
+//
+//  Timing accuracy model for the Lite scheduler diagnostic tab.
+//  Passively records each scheduled click's timing error (delta between
+//  scheduled fire time and actual fire time) and aggregates session stats.
+//
+
+import Foundation
+import Observation
+
+// MARK: - TimingRecord
+
+/// A single timing observation from one scheduled click firing.
+struct TimingRecord {
+    /// The time the click was scheduled to fire.
+    let scheduledAt: Date
+    /// The time the click actually fired (captured at the top of the execution handler).
+    let actualAt: Date
+
+    /// Difference in milliseconds: positive = late, negative = early.
+    var deltaMs: Double {
+        (actualAt.timeIntervalSince(scheduledAt)) * 1000.0
+    }
+
+    /// Accuracy severity based on the absolute delta.
+    var severity: Severity {
+        Severity(delta: deltaMs)
+    }
+
+    // MARK: Severity
+
+    enum Severity: Equatable {
+        /// |delta| ≤ 10ms — within ClickIt's sub-10ms accuracy goal.
+        case green
+        /// 10ms < |delta| ≤ 50ms — degraded.
+        case yellow
+        /// |delta| > 50ms — unacceptable.
+        case red
+
+        init(delta: Double) {
+            let abs = Swift.abs(delta)
+            if abs <= 10.0 {
+                self = .green
+            } else if abs <= 50.0 {
+                self = .yellow
+            } else {
+                self = .red
+            }
+        }
+    }
+}
+
+// MARK: - DiagnosticSession
+
+/// Session-scoped accumulator of `TimingRecord` values.
+/// Resets on app launch (in-memory only, no persistence).
+@Observable
+final class DiagnosticSession {
+
+    // MARK: - Public State
+
+    /// Total number of firings recorded this session.
+    private(set) var totalCount: Int = 0
+
+    /// Smallest delta (in ms) recorded this session; `nil` if no firings yet.
+    private(set) var minDeltaMs: Double?
+
+    /// Largest delta (in ms) recorded this session; `nil` if no firings yet.
+    private(set) var maxDeltaMs: Double?
+
+    /// Mean delta (in ms) across all firings; `nil` if no firings yet.
+    private(set) var averageDeltaMs: Double?
+
+    // MARK: - Private State
+
+    private var runningSum: Double = 0.0
+
+    // MARK: - Public API
+
+    /// Record a new timing observation and update session statistics.
+    func add(_ record: TimingRecord) {
+        let abs = Swift.abs(record.deltaMs)
+
+        totalCount += 1
+        runningSum += abs
+
+        if let current = minDeltaMs {
+            minDeltaMs = Swift.min(current, abs)
+        } else {
+            minDeltaMs = abs
+        }
+
+        if let current = maxDeltaMs {
+            maxDeltaMs = Swift.max(current, abs)
+        } else {
+            maxDeltaMs = abs
+        }
+
+        averageDeltaMs = runningSum / Double(totalCount)
+    }
+}

--- a/Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticTabView.swift
+++ b/Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticTabView.swift
@@ -1,0 +1,157 @@
+//
+//  DiagnosticTabView.swift
+//  ClickIt Lite
+//
+//  In-app diagnostic tab for the Lite scheduler.
+//  Passively displays timing accuracy data recorded by LiteScheduler
+//  each time a scheduled click fires.
+//
+
+import SwiftUI
+
+struct DiagnosticTabView: View {
+
+    // MARK: - Properties
+
+    @State var session: DiagnosticSession
+
+    // MARK: - Computed Properties
+
+    /// Severity based on the worst (max) delta recorded this session.
+    /// `nil` when no firings have been observed yet.
+    var badgeSeverity: TimingRecord.Severity? {
+        guard let max = session.maxDeltaMs else { return nil }
+        return TimingRecord.Severity(delta: max)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if session.totalCount == 0 {
+                emptyStateView
+            } else {
+                statsView
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    // MARK: - Subviews
+
+    private var emptyStateView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "waveform.path.ecg")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text("No Timing Data Yet")
+                .font(.headline)
+            Text("Schedule a click to see accuracy measurements.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, 40)
+    }
+
+    private var statsView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Severity badge
+            HStack {
+                Text("Accuracy")
+                    .font(.headline)
+                Spacer()
+                if let severity = badgeSeverity {
+                    SeverityBadge(severity: severity)
+                }
+            }
+
+            Divider()
+
+            // Stats grid
+            VStack(spacing: 10) {
+                statRow(label: "Firings", value: "\(session.totalCount)")
+                if let min = session.minDeltaMs {
+                    statRow(label: "Min Delta", value: formatDelta(min))
+                }
+                if let max = session.maxDeltaMs {
+                    statRow(label: "Max Delta", value: formatDelta(max))
+                }
+                if let avg = session.averageDeltaMs {
+                    statRow(label: "Avg Delta", value: formatDelta(avg))
+                }
+            }
+        }
+    }
+
+    private func statRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .monospacedDigit()
+                .fontWeight(.medium)
+        }
+        .font(.subheadline)
+    }
+
+    private func formatDelta(_ ms: Double) -> String {
+        String(format: "%.1f ms", ms)
+    }
+}
+
+// MARK: - SeverityBadge
+
+private struct SeverityBadge: View {
+    let severity: TimingRecord.Severity
+
+    var body: some View {
+        Text(label)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+    }
+
+    private var label: String {
+        switch severity {
+        case .green:  return "Good"
+        case .yellow: return "Degraded"
+        case .red:    return "Poor"
+        }
+    }
+
+    private var color: Color {
+        switch severity {
+        case .green:  return .green
+        case .yellow: return .orange
+        case .red:    return .red
+        }
+    }
+}
+
+// MARK: - Preview
+
+struct DiagnosticTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        let emptySession = DiagnosticSession()
+        let populatedSession = DiagnosticSession()
+        let scheduled = Date(timeIntervalSinceReferenceDate: 1000.0)
+        populatedSession.add(TimingRecord(scheduledAt: scheduled,
+                                          actualAt: scheduled.addingTimeInterval(0.007)))
+        populatedSession.add(TimingRecord(scheduledAt: scheduled,
+                                          actualAt: scheduled.addingTimeInterval(0.012)))
+
+        return Group {
+            DiagnosticTabView(session: emptySession)
+                .previewDisplayName("Empty State")
+            DiagnosticTabView(session: populatedSession)
+                .previewDisplayName("With Data")
+        }
+    }
+}

--- a/Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticTabView.swift
+++ b/Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticTabView.swift
@@ -13,7 +13,7 @@ struct DiagnosticTabView: View {
 
     // MARK: - Properties
 
-    @State var session: DiagnosticSession
+    let session: DiagnosticSession
 
     // MARK: - Computed Properties
 

--- a/Tests/ClickItTests/DiagnosticTabViewTests.swift
+++ b/Tests/ClickItTests/DiagnosticTabViewTests.swift
@@ -1,0 +1,115 @@
+//
+//  DiagnosticTabViewTests.swift
+//  ClickIt Tests
+//
+//  TDD Red: Tests for DiagnosticTabView.
+//  Verifies view can be instantiated in empty and populated states,
+//  and that the session model drives the expected display values.
+//
+
+import XCTest
+import SwiftUI
+@testable import ClickItLiteUI
+
+@MainActor
+final class DiagnosticTabViewTests: XCTestCase {
+
+    // MARK: - View Instantiation
+
+    func testDiagnosticTabView_canBeCreated_withEmptySession() {
+        let session = DiagnosticSession()
+        let view = DiagnosticTabView(session: session)
+        XCTAssertNotNil(view, "DiagnosticTabView should initialise with an empty session")
+    }
+
+    func testDiagnosticTabView_canBeCreated_withPopulatedSession() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 8.0))
+        session.add(makeRecord(latencyMs: 25.0))
+        let view = DiagnosticTabView(session: session)
+        XCTAssertNotNil(view, "DiagnosticTabView should initialise with a populated session")
+    }
+
+    // MARK: - Empty State
+
+    func testEmptySession_hasNoStats() {
+        let session = DiagnosticSession()
+        XCTAssertEqual(session.totalCount, 0)
+        XCTAssertNil(session.minDeltaMs)
+        XCTAssertNil(session.maxDeltaMs)
+        XCTAssertNil(session.averageDeltaMs)
+    }
+
+    // MARK: - Stats Display Values
+
+    func testStats_afterOneFiring_allStatsPresent() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 7.0))
+
+        XCTAssertEqual(session.totalCount, 1)
+        XCTAssertNotNil(session.minDeltaMs)
+        XCTAssertNotNil(session.maxDeltaMs)
+        XCTAssertNotNil(session.averageDeltaMs)
+    }
+
+    func testStats_multipleFireings_correctValues() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 4.0))
+        session.add(makeRecord(latencyMs: 8.0))
+        session.add(makeRecord(latencyMs: 12.0))
+
+        XCTAssertEqual(session.totalCount, 3)
+        XCTAssertEqual(session.minDeltaMs!, 4.0, accuracy: 0.001)
+        XCTAssertEqual(session.maxDeltaMs!, 12.0, accuracy: 0.001)
+        XCTAssertEqual(session.averageDeltaMs!, 8.0, accuracy: 0.001)
+    }
+
+    // MARK: - Severity Badge Color Tier
+
+    func testSeverityColor_green_forGoodTiming() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 5.0))
+        let view = DiagnosticTabView(session: session)
+        XCTAssertEqual(view.badgeSeverity, .green)
+    }
+
+    func testSeverityColor_yellow_forDegradedTiming() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 25.0))
+        let view = DiagnosticTabView(session: session)
+        XCTAssertEqual(view.badgeSeverity, .yellow)
+    }
+
+    func testSeverityColor_red_forUnacceptableTiming() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 100.0))
+        let view = DiagnosticTabView(session: session)
+        XCTAssertEqual(view.badgeSeverity, .red)
+    }
+
+    func testSeverityColor_nil_forEmptySession() {
+        let session = DiagnosticSession()
+        let view = DiagnosticTabView(session: session)
+        XCTAssertNil(view.badgeSeverity)
+    }
+
+    func testSeverityColor_reflectsMaxDelta_notAverage() {
+        // One very late firing should push severity to red
+        // even if the average is within green range.
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 2.0))
+        session.add(makeRecord(latencyMs: 2.0))
+        session.add(makeRecord(latencyMs: 100.0))
+        let view = DiagnosticTabView(session: session)
+        XCTAssertEqual(view.badgeSeverity, .red,
+            "Badge should reflect worst (max) delta, not average")
+    }
+
+    // MARK: - Helpers
+
+    private func makeRecord(latencyMs: Double) -> TimingRecord {
+        let scheduled = Date(timeIntervalSinceReferenceDate: 1000.0)
+        let actual = scheduled.addingTimeInterval(latencyMs / 1000.0)
+        return TimingRecord(scheduledAt: scheduled, actualAt: actual)
+    }
+}

--- a/Tests/ClickItTests/LiteDiagnosticIntegrationTests.swift
+++ b/Tests/ClickItTests/LiteDiagnosticIntegrationTests.swift
@@ -1,0 +1,59 @@
+//
+//  LiteDiagnosticIntegrationTests.swift
+//  ClickIt Tests
+//
+//  TDD Red: Integration tests confirming DiagnosticSession is wired
+//  through SimpleViewModel and receives timing records when a
+//  scheduled click fires.
+//
+
+import XCTest
+import SwiftUI
+@testable import ClickItLiteUI
+
+@MainActor
+final class LiteDiagnosticIntegrationTests: XCTestCase {
+
+    // MARK: - SimpleViewModel Exposes DiagnosticSession
+
+    func testSimpleViewModel_exposesDiagnosticSession() {
+        let viewModel = SimpleViewModel()
+        XCTAssertNotNil(viewModel.diagnosticSession,
+            "SimpleViewModel must expose a DiagnosticSession for the diagnostic tab")
+    }
+
+    // MARK: - SimplifiedMainView Instantiates with TabView
+
+    func testSimplifiedMainView_canBeCreated() {
+        let view = SimplifiedMainView()
+        XCTAssertNotNil(view, "SimplifiedMainView should initialise successfully with diagnostic tab")
+    }
+
+    // MARK: - Session Receives Timing Records via ViewModel
+
+    func testDiagnosticSession_receivesRecord_whenScheduledClickFires() async throws {
+        let viewModel = SimpleViewModel()
+        let session = viewModel.diagnosticSession
+
+        XCTAssertEqual(session.totalCount, 0, "Session starts empty")
+
+        // Use LiteScheduler directly to fire a timing record through the same
+        // onTimingRecord callback that the view model wires up.
+        let scheduler = LiteScheduler()
+        let expectation = expectation(description: "timing record received")
+
+        scheduler.onTimingRecord = { record in
+            session.add(record)
+            expectation.fulfill()
+        }
+
+        _ = scheduler.schedule(for: Date().addingTimeInterval(1.0), task: {})
+        await fulfillment(of: [expectation], timeout: 3.0)
+
+        XCTAssertEqual(session.totalCount, 1,
+            "Session should have 1 record after one firing")
+        XCTAssertNotNil(session.minDeltaMs)
+        XCTAssertNotNil(session.maxDeltaMs)
+        XCTAssertNotNil(session.averageDeltaMs)
+    }
+}

--- a/Tests/ClickItTests/LiteDiagnosticIntegrationTests.swift
+++ b/Tests/ClickItTests/LiteDiagnosticIntegrationTests.swift
@@ -29,26 +29,23 @@ final class LiteDiagnosticIntegrationTests: XCTestCase {
         XCTAssertNotNil(view, "SimplifiedMainView should initialise successfully with diagnostic tab")
     }
 
-    // MARK: - Session Receives Timing Records via ViewModel
+    // MARK: - Session Receives Timing Records via ViewModel Wiring
 
     func testDiagnosticSession_receivesRecord_whenScheduledClickFires() async throws {
-        let viewModel = SimpleViewModel()
+        // Inject a no-op click action so no permissions are needed in CI.
+        let testManager = ScheduledClickManager(clickAction: {})
+        let viewModel = SimpleViewModel(scheduledClickManager: testManager)
         let session = viewModel.diagnosticSession
 
         XCTAssertEqual(session.totalCount, 0, "Session starts empty")
 
-        // Use LiteScheduler directly to fire a timing record through the same
-        // onTimingRecord callback that the view model wires up.
-        let scheduler = LiteScheduler()
-        let expectation = expectation(description: "timing record received")
+        try viewModel.scheduleClick(at: Date().addingTimeInterval(0.2))
 
-        scheduler.onTimingRecord = { record in
-            session.add(record)
-            expectation.fulfill()
+        // Poll until the session is updated or we time out.
+        let deadline = Date.now.addingTimeInterval(2.0)
+        while session.totalCount == 0 && Date.now < deadline {
+            try await Task.sleep(for: .milliseconds(50))
         }
-
-        _ = scheduler.schedule(for: Date().addingTimeInterval(1.0), task: {})
-        await fulfillment(of: [expectation], timeout: 3.0)
 
         XCTAssertEqual(session.totalCount, 1,
             "Session should have 1 record after one firing")

--- a/Tests/ClickItTests/LiteSchedulerTimingTests.swift
+++ b/Tests/ClickItTests/LiteSchedulerTimingTests.swift
@@ -1,0 +1,114 @@
+//
+//  LiteSchedulerTimingTests.swift
+//  ClickIt Tests
+//
+//  TDD Red: Tests for LiteScheduler timing instrumentation.
+//  Verifies that onTimingRecord delivers an accurate TimingRecord
+//  when a scheduled task fires.
+//
+
+import XCTest
+@testable import ClickItLiteUI
+
+@MainActor
+final class LiteSchedulerTimingTests: XCTestCase {
+
+    // MARK: - onTimingRecord Callback
+
+    func testOnTimingRecord_calledWhenTaskFires() async throws {
+        let scheduler = LiteScheduler()
+        let expectation = expectation(description: "onTimingRecord called")
+
+        scheduler.onTimingRecord = { _ in
+            expectation.fulfill()
+        }
+
+        _ = scheduler.schedule(for: Date().addingTimeInterval(1.0), task: {})
+
+        await fulfillment(of: [expectation], timeout: 3.0)
+    }
+
+    func testOnTimingRecord_scheduledAt_matchesTargetDate() async throws {
+        let scheduler = LiteScheduler()
+        let targetDate = Date().addingTimeInterval(1.0)
+        var receivedRecord: TimingRecord?
+        let expectation = expectation(description: "onTimingRecord received")
+
+        scheduler.onTimingRecord = { record in
+            receivedRecord = record
+            expectation.fulfill()
+        }
+
+        _ = scheduler.schedule(for: targetDate, task: {})
+
+        await fulfillment(of: [expectation], timeout: 3.0)
+
+        let record = try XCTUnwrap(receivedRecord)
+        XCTAssertEqual(record.scheduledAt.timeIntervalSinceReferenceDate,
+                       targetDate.timeIntervalSinceReferenceDate,
+                       accuracy: 0.001,
+                       "scheduledAt should match the date passed to schedule(for:task:)")
+    }
+
+    func testOnTimingRecord_actualAt_capturedAtFiringTime() async throws {
+        let scheduler = LiteScheduler()
+        let targetDate = Date().addingTimeInterval(1.0)
+        var receivedRecord: TimingRecord?
+        let beforeFire = Date()
+        let expectation = expectation(description: "onTimingRecord received")
+
+        scheduler.onTimingRecord = { record in
+            receivedRecord = record
+            expectation.fulfill()
+        }
+
+        _ = scheduler.schedule(for: targetDate, task: {})
+
+        await fulfillment(of: [expectation], timeout: 3.0)
+
+        let afterFire = Date()
+        let record = try XCTUnwrap(receivedRecord)
+
+        XCTAssertGreaterThanOrEqual(record.actualAt, beforeFire,
+            "actualAt should not be before the scheduler started")
+        XCTAssertLessThanOrEqual(record.actualAt, afterFire,
+            "actualAt should not be after the callback was received")
+    }
+
+    func testOnTimingRecord_deltaMs_isReasonablySmall() async throws {
+        let scheduler = LiteScheduler()
+        var receivedRecord: TimingRecord?
+        let expectation = expectation(description: "onTimingRecord received")
+
+        scheduler.onTimingRecord = { record in
+            receivedRecord = record
+            expectation.fulfill()
+        }
+
+        _ = scheduler.schedule(for: Date().addingTimeInterval(1.0), task: {})
+
+        await fulfillment(of: [expectation], timeout: 3.0)
+
+        let record = try XCTUnwrap(receivedRecord)
+        XCTAssertLessThan(abs(record.deltaMs), 200.0,
+            "delta should be within 200ms for a 1-second schedule (was \(record.deltaMs)ms)")
+    }
+
+    func testOnTimingRecord_notCalledAfterCancel() async throws {
+        let scheduler = LiteScheduler()
+        var callCount = 0
+        let expectation = expectation(description: "waited without callback")
+        expectation.isInverted = true
+
+        scheduler.onTimingRecord = { _ in
+            callCount += 1
+            expectation.fulfill()
+        }
+
+        _ = scheduler.schedule(for: Date().addingTimeInterval(1.0), task: {})
+        scheduler.cancel()
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        XCTAssertEqual(callCount, 0, "onTimingRecord should not fire after cancel")
+    }
+}

--- a/Tests/ClickItTests/TimingDiagnosticTests.swift
+++ b/Tests/ClickItTests/TimingDiagnosticTests.swift
@@ -1,0 +1,138 @@
+//
+//  TimingDiagnosticTests.swift
+//  ClickIt Tests
+//
+
+import XCTest
+@testable import ClickItLiteUI
+
+final class TimingDiagnosticTests: XCTestCase {
+
+    // MARK: - TimingRecord.Severity
+
+    func testSeverity_green_whenDeltaAtOrBelowTenMs() {
+        let severities: [(Double, TimingRecord.Severity)] = [
+            (0.0, .green),
+            (5.0, .green),
+            (10.0, .green),
+        ]
+        for (delta, expected) in severities {
+            XCTAssertEqual(TimingRecord.Severity(delta: delta), expected,
+                "delta \(delta)ms should be .green")
+        }
+    }
+
+    func testSeverity_yellow_whenDeltaBetweenTenAndFiftyMs() {
+        let severities: [(Double, TimingRecord.Severity)] = [
+            (10.1, .yellow),
+            (25.0, .yellow),
+            (50.0, .yellow),
+        ]
+        for (delta, expected) in severities {
+            XCTAssertEqual(TimingRecord.Severity(delta: delta), expected,
+                "delta \(delta)ms should be .yellow")
+        }
+    }
+
+    func testSeverity_red_whenDeltaAboveFiftyMs() {
+        let severities: [(Double, TimingRecord.Severity)] = [
+            (50.1, .red),
+            (100.0, .red),
+            (500.0, .red),
+        ]
+        for (delta, expected) in severities {
+            XCTAssertEqual(TimingRecord.Severity(delta: delta), expected,
+                "delta \(delta)ms should be .red")
+        }
+    }
+
+    func testSeverity_usesAbsoluteDelta_forNegative() {
+        // Negative delta (early) uses absolute value for severity
+        XCTAssertEqual(TimingRecord.Severity(delta: -5.0), .green)
+        XCTAssertEqual(TimingRecord.Severity(delta: -25.0), .yellow)
+        XCTAssertEqual(TimingRecord.Severity(delta: -100.0), .red)
+    }
+
+    // MARK: - TimingRecord
+
+    func testTimingRecord_delta_isPositiveWhenLate() {
+        let scheduled = Date(timeIntervalSinceReferenceDate: 1000.0)
+        let actual = Date(timeIntervalSinceReferenceDate: 1000.010) // 10ms late
+        let record = TimingRecord(scheduledAt: scheduled, actualAt: actual)
+        XCTAssertEqual(record.deltaMs, 10.0, accuracy: 0.001)
+    }
+
+    func testTimingRecord_delta_isNegativeWhenEarly() {
+        let scheduled = Date(timeIntervalSinceReferenceDate: 1000.0)
+        let actual = Date(timeIntervalSinceReferenceDate: 999.995) // 5ms early
+        let record = TimingRecord(scheduledAt: scheduled, actualAt: actual)
+        XCTAssertEqual(record.deltaMs, -5.0, accuracy: 0.001)
+    }
+
+    func testTimingRecord_severity_derivedFromDelta() {
+        let scheduled = Date(timeIntervalSinceReferenceDate: 1000.0)
+        let actual = Date(timeIntervalSinceReferenceDate: 1000.005) // 5ms late
+        let record = TimingRecord(scheduledAt: scheduled, actualAt: actual)
+        XCTAssertEqual(record.severity, .green)
+    }
+
+    // MARK: - DiagnosticSession
+
+    func testDiagnosticSession_startsEmpty() {
+        let session = DiagnosticSession()
+        XCTAssertEqual(session.totalCount, 0)
+        XCTAssertNil(session.minDeltaMs)
+        XCTAssertNil(session.maxDeltaMs)
+        XCTAssertNil(session.averageDeltaMs)
+    }
+
+    func testDiagnosticSession_addRecord_incrementsCount() {
+        let session = DiagnosticSession()
+        let record = makeRecord(latencyMs: 5.0)
+        session.add(record)
+        XCTAssertEqual(session.totalCount, 1)
+    }
+
+    func testDiagnosticSession_minDelta_tracksSmallestAbsoluteValue() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 20.0))
+        session.add(makeRecord(latencyMs: 5.0))
+        session.add(makeRecord(latencyMs: 15.0))
+        XCTAssertEqual(session.minDeltaMs!, 5.0, accuracy: 0.001)
+    }
+
+    func testDiagnosticSession_maxDelta_tracksLargestAbsoluteValue() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 20.0))
+        session.add(makeRecord(latencyMs: 5.0))
+        session.add(makeRecord(latencyMs: 100.0))
+        XCTAssertEqual(session.maxDeltaMs!, 100.0, accuracy: 0.001)
+    }
+
+    func testDiagnosticSession_averageDelta_isCorrect() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 10.0))
+        session.add(makeRecord(latencyMs: 20.0))
+        session.add(makeRecord(latencyMs: 30.0))
+        XCTAssertEqual(session.averageDeltaMs!, 20.0, accuracy: 0.001)
+    }
+
+    func testDiagnosticSession_multipleRecords_statsUpdateCorrectly() {
+        let session = DiagnosticSession()
+        session.add(makeRecord(latencyMs: 8.0))
+        session.add(makeRecord(latencyMs: 12.0))
+
+        XCTAssertEqual(session.totalCount, 2)
+        XCTAssertEqual(session.minDeltaMs!, 8.0, accuracy: 0.001)
+        XCTAssertEqual(session.maxDeltaMs!, 12.0, accuracy: 0.001)
+        XCTAssertEqual(session.averageDeltaMs!, 10.0, accuracy: 0.001)
+    }
+
+    // MARK: - Helpers
+
+    private func makeRecord(latencyMs: Double) -> TimingRecord {
+        let scheduled = Date(timeIntervalSinceReferenceDate: 1000.0)
+        let actual = scheduled.addingTimeInterval(latencyMs / 1000.0)
+        return TimingRecord(scheduledAt: scheduled, actualAt: actual)
+    }
+}

--- a/conductor/patterns.md
+++ b/conductor/patterns.md
@@ -36,6 +36,9 @@ Reusable patterns discovered during development. Read this before starting new w
 ## SwiftUI Date/Time Pickers
 - **Truncate seconds for `DatePicker` with `.hourAndMinute`**: The picker displays only hour:minute, but `Date()` carries seconds. Always zero out seconds before scheduling: extract `[.year, .month, .day, .hour, .minute]` components and set `second = 0`. Initialize picker defaults with a `nextMinute()` helper (same truncation) so displayed time matches fired time. (from: datetime_scheduler_20260320, 2026-03-21)
 
+## Swift Actor Isolation (additions)
+- **`@MainActor` init cannot be used as a default parameter expression** — use `nil` default and construct the instance inside the `@MainActor`-isolated init body instead; use `self.` prefix when a parameter name shadows a stored property (from: timingdiag_20260321, 2026-03-23)
+
 ## Swift Actor Isolation
 - **`nonisolated` + `MainActor.assumeIsolated` for static defaults**: Default parameter expressions cannot call `@MainActor` methods. Mark the static method `nonisolated` and wrap the AppKit/UIKit calls in `MainActor.assumeIsolated { }` — safe when the method is always invoked from an `@MainActor` call site. (from: datetime_scheduler_20260320, 2026-03-21)
 - **`onFired` callback over Combine for transient state**: If a state transition (e.g. `.fired`) is set and immediately reset in the same synchronous call, Combine subscribers won't see it — the value is already overwritten before the publisher fires. Use an explicit callback property (`var onFired: (() -> Void)?`) instead. (from: datetime_scheduler_20260320, 2026-03-21)
@@ -53,6 +56,7 @@ Reusable patterns discovered during development. Read this before starting new w
 
 ## SwiftUI @Observable
 - **`@Observable` class property can be `let` on a ViewModel** — no `@Published` needed; SwiftUI tracks changes through the `@Observable` macro automatically (from: timingdiag_20260321, 2026-03-23)
+- **Passed-in `@Observable` objects should be `let`, not `@State`** — `@State` implies ownership/creation by the view; for injected `@Observable` instances SwiftUI tracks changes without it (from: timingdiag_20260321, 2026-03-23)
 - **Expose computed display properties as `internal` (not `private`) on SwiftUI views** — allows tests to assert on derived state (e.g. `badgeSeverity`) without needing a renderer or snapshot framework (from: timingdiag_20260321, 2026-03-23)
 - **`TabView` adds ~40px chrome** — adjust window frame when introducing tabs to an existing fixed-size window (from: timingdiag_20260321, 2026-03-23)
 

--- a/conductor/patterns.md
+++ b/conductor/patterns.md
@@ -51,5 +51,19 @@ Reusable patterns discovered during development. Read this before starting new w
 - Run Xcode tests without `sudo xcode-select`: prefix with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` and use full toolchain path `...Toolchains/XcodeDefault.xctoolchain/usr/bin/swift test` (from: lite_stabilization_20260319, 2026-03-19)
 - 3 known flaky tests in the suite: `testPatternBreakup` (random boundary condition), `testHighFrequencyCPSAccuracy` (timing precision, fails in debug mode), `testErrorRecoveryIntegration` (timing-sensitive) — not regressions (from: lite_stabilization_20260319 + cicd_optimization_20260319, 2026-03-20)
 
+## SwiftUI @Observable
+- **`@Observable` class property can be `let` on a ViewModel** — no `@Published` needed; SwiftUI tracks changes through the `@Observable` macro automatically (from: timingdiag_20260321, 2026-03-23)
+- **Expose computed display properties as `internal` (not `private`) on SwiftUI views** — allows tests to assert on derived state (e.g. `badgeSeverity`) without needing a renderer or snapshot framework (from: timingdiag_20260321, 2026-03-23)
+- **`TabView` adds ~40px chrome** — adjust window frame when introducing tabs to an existing fixed-size window (from: timingdiag_20260321, 2026-03-23)
+
+## SPM Multi-Target Sharing (additions)
+- **New Lite/ subdirectory: exclude by directory name in `ClickItLite` target**, not individual files — e.g. `"TimingDiagnostic"` covers all files added later without further `Package.swift` edits (from: timingdiag_20260321, 2026-03-23)
+
+## Timing & Precision
+- **Capture `Date()` as the very first line of a timing-sensitive handler** — any timer cancellation or nil-clearing before the capture adds measurable nanoseconds to the recorded delta (from: timingdiag_20260321, 2026-03-23)
+
+## Testing
+- **Integration tests for scheduler callbacks: use `LiteScheduler` directly** (not `ScheduledClickManager`) to avoid needing Accessibility permissions in CI — permissions are only checked at click-fire time, not at schedule time (from: timingdiag_20260321, 2026-03-23)
+
 ---
-Last refreshed: 2026-03-21 (litescheduler_20260321)
+Last refreshed: 2026-03-23 (timingdiag_20260321)

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -6,3 +6,8 @@ This file tracks all major tracks for the project.
 
 ## [x] Track: Replace Timer with DispatchSourceTimer in ScheduledClickManager (High-Precision Scheduler)
 *Link: [./conductor/tracks/litescheduler_20260321/](./conductor/tracks/litescheduler_20260321/)*
+
+---
+
+## [x] Track: Lite Scheduler Timing Diagnostic Screen
+*Link: [./conductor/tracks/timingdiag_20260321/](./conductor/tracks/timingdiag_20260321/)*

--- a/conductor/tracks/timingdiag_20260321/learnings.md
+++ b/conductor/tracks/timingdiag_20260321/learnings.md
@@ -1,0 +1,92 @@
+# Track Learnings: timingdiag_20260321
+
+Patterns, gotchas, and context discovered during implementation.
+
+## Codebase Patterns (Inherited)
+
+- Use `PreviewProvider` struct instead of `#Preview {}` macro — fails with `swift build`
+- New `Lite/` source files must be excluded from `ClickItLite` target in `Package.swift` — otherwise SPM reports "overlapping sources"
+- Use `@testable import ClickItLiteUI` (not `@testable import ClickIt`) for testing Lite internals
+- `@Observable` class for SwiftUI binding; UI updates on main thread, timing capture on scheduler's dispatch queue
+- `nonisolated` + `MainActor.assumeIsolated` for static defaults that call `@MainActor` methods
+- Use explicit callback property (`var onFired: (() -> Void)?`) over Combine for transient state — Combine won't see values set and immediately reset in the same synchronous call
+- GCD unresumed DispatchSource crash: every created `DispatchSourceTimer` must be resumed or explicitly cancelled before discard
+- Swift 6 strict concurrency: test classes accessing `@MainActor`-isolated types must be annotated `@MainActor`
+
+---
+
+<!-- Learnings from implementation will be appended below -->
+
+## [2026-03-22] - Phase 3 Task 1: TDD Red — Integration tests
+- **Implemented:** LiteDiagnosticIntegrationTests (SimpleViewModel.diagnosticSession not yet added)
+- **Files changed:** Tests/ClickItTests/LiteDiagnosticIntegrationTests.swift
+- **Commit:** 3eeead5
+- **Learnings:**
+  - Patterns: Integration tests for scheduler callbacks use LiteScheduler directly (not full ScheduledClickManager) to avoid needing accessibility permissions in CI
+---
+
+## [2026-03-22] - Phase 3 Task 2: Add Diagnostic tab to Lite UI
+- **Implemented:** SimpleViewModel.diagnosticSession + onTimingRecord wiring + TabView in SimplifiedMainView
+- **Files changed:** SimpleViewModel.swift, SimplifiedMainView.swift
+- **Commit:** 4983d11
+- **Learnings:**
+  - Patterns: @Observable class property can be `let` on a ViewModel — no need for @Published; SwiftUI tracks changes through the @Observable macro
+  - Patterns: Moving existing VStack into a named computed var (`mainTab`) before wrapping in TabView keeps diffs clean and body readable
+  - Gotchas: TabView adds chrome (~40px) — adjust window frame when introducing tabs to an existing fixed-size window
+  - Gotchas: No Package.swift change needed when new files live in an already-excluded directory (TimingDiagnostic/ was excluded at the directory level)
+---
+
+## [2026-03-22] - Phase 2 Task 1: TDD Red — DiagnosticTabView tests
+- **Implemented:** Test file for DiagnosticTabView (not yet created at commit time)
+- **Files changed:** Tests/ClickItTests/DiagnosticTabViewTests.swift
+- **Commit:** ea48d2e
+- **Learnings:**
+  - Patterns: For @Observable SwiftUI views, expose computed display properties (badgeSeverity) as internal vars so tests can assert on them without rendering
+  - Gotchas: Badge severity uses max delta not average — key product decision worth testing explicitly
+---
+
+## [2026-03-22] - Phase 2 Task 2: Implement DiagnosticTabView
+- **Implemented:** DiagnosticTabView + SeverityBadge in Lite/TimingDiagnostic/
+- **Files changed:** Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticTabView.swift
+- **Commit:** 2128ffa
+- **Learnings:**
+  - Patterns: @Observable class works with @State var in SwiftUI — no need for @Bindable when session is owned by the view
+  - Patterns: File-private helper views (SeverityBadge) in the same file keep the public API surface clean
+  - Gotchas: DiagnosticTabView.swift lives in TimingDiagnostic/ subdir — already excluded from ClickItLite target via directory-level exclude in Package.swift
+---
+
+## [2026-03-21] - Phase 1 Task 2: TDD Red — TimingRecord & DiagnosticSession tests
+- **Implemented:** Test file for model types (does not exist yet at commit time)
+- **Files changed:** Tests/ClickItTests/TimingDiagnosticTests.swift
+- **Commit:** 31298a1
+- **Learnings:**
+  - Patterns: Tests live flat in Tests/ClickItTests/ — no Lite/ subdirectory exists
+  - Gotchas: Severity uses abs(delta) so negative (early) and positive (late) share same tier thresholds
+---
+
+## [2026-03-21] - Phase 1 Task 3: Implement TimingRecord and DiagnosticSession
+- **Implemented:** TimingRecord struct + DiagnosticSession @Observable in Lite/TimingDiagnostic/
+- **Files changed:** Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticSession.swift, Package.swift
+- **Commit:** f9c2e7b
+- **Learnings:**
+  - Patterns: New subdirectory under Lite/ must be added to ClickItLite exclude list as the directory name (e.g. "TimingDiagnostic") not individual files
+  - Gotchas: DiagnosticSession tracks abs(delta) for min/max/avg — signed delta lives on TimingRecord.deltaMs only
+---
+
+## [2026-03-21] - Phase 1 Task 4: TDD Red — LiteScheduler timing instrumentation
+- **Implemented:** LiteSchedulerTimingTests covering onTimingRecord (not yet implemented)
+- **Files changed:** Tests/ClickItTests/LiteSchedulerTimingTests.swift
+- **Commit:** 0485683
+- **Learnings:**
+  - Patterns: inverted expectations (isInverted = true) cleanly test "callback not called after cancel"
+---
+
+## [2026-03-21] - Phase 1 Task 5: Instrument LiteScheduler
+- **Implemented:** onTimingRecord callback + ScheduledClickManager forwarding
+- **Files changed:** LiteScheduler.swift, ScheduledClickManager.swift
+- **Commit:** e67511e
+- **Learnings:**
+  - Patterns: Capture actualAt = Date() as the very first line of executeTask() before cancelling timers — any timer cancellation or nil-clearing adds measurable nanoseconds
+  - Patterns: ScheduledClickManager can forward LiteScheduler callbacks as computed properties (get/set) — avoids a re-wiring step during schedule()
+  - Context: onTimingRecord is delivered on main queue, after task() and executionHandler(), so observers always see the fired state before the timing record arrives
+---

--- a/conductor/tracks/timingdiag_20260321/metadata.json
+++ b/conductor/tracks/timingdiag_20260321/metadata.json
@@ -1,0 +1,26 @@
+{
+  "track_id": "timingdiag_20260321",
+  "type": "feature",
+  "status": "complete",
+  "priority": "critical",
+  "depends_on": [],
+  "estimated_hours": 1,
+  "created_at": "2026-03-21T00:00:00Z",
+  "updated_at": "2026-03-21T00:00:00Z",
+  "description": "In-app diagnostic tab for ClickIt Lite that passively observes LiteScheduler and displays scheduled click timing accuracy.",
+  "beads_epic": "ClickIt-3dh",
+  "beads_tasks": {
+    "phase1": "ClickIt-3dh.1",
+    "phase1_task1": "ClickIt-3dh.1.1",
+    "phase1_task2": "ClickIt-3dh.1.2",
+    "phase1_task3": "ClickIt-3dh.1.3",
+    "phase1_task4": "ClickIt-3dh.1.4",
+    "phase1_task5": "ClickIt-3dh.1.5",
+    "phase2": "ClickIt-3dh.2",
+    "phase2_task1": "ClickIt-3dh.2.1",
+    "phase2_task2": "ClickIt-3dh.2.2",
+    "phase3": "ClickIt-3dh.3",
+    "phase3_task1": "ClickIt-3dh.3.1",
+    "phase3_task2": "ClickIt-3dh.3.2"
+  }
+}

--- a/conductor/tracks/timingdiag_20260321/plan.md
+++ b/conductor/tracks/timingdiag_20260321/plan.md
@@ -1,0 +1,57 @@
+# Plan: Lite Scheduler Timing Diagnostic Screen
+
+## Phase 1: Timing Data Model & Scheduler Instrumentation
+
+- [x] Task: Create git branch `feat/timing-diagnostic-screen`
+  - Run: `git checkout -b feat/timing-diagnostic-screen`
+
+- [x] Task (TDD Red): Write tests for `TimingRecord` and `DiagnosticSession` models
+  - `TimingRecord`: scheduledAt, actualAt, delta (computed), severity (green/yellow/red)
+  - `DiagnosticSession`: array of records, min/max/avg delta, total count
+  - Tests in `Tests/ClickItTests/Lite/TimingDiagnosticTests.swift`
+
+- [x] Task: Implement `TimingRecord` and `DiagnosticSession` models
+  - New file: `Sources/ClickIt/Lite/TimingDiagnostic/DiagnosticSession.swift`
+  - Severity enum: `green` (≤10ms), `yellow` (10–50ms), `red` (>50ms)
+  - Make `DiagnosticSession` an `@Observable` class for SwiftUI binding
+
+- [x] Task (TDD Red): Write tests for LiteScheduler timing instrumentation
+  - Verify `scheduledAt` timestamp is captured when scheduler is armed
+  - Verify `actualAt` timestamp is captured inside the execution handler
+  - Verify callback delivers a `TimingRecord` to the observer
+
+- [x] Task: Instrument `LiteScheduler` to emit timing records
+  - Capture `scheduledAt` when `schedule(at:)` is called
+  - Capture `actualAt` at the top of the execution handler (before any other work)
+  - Add `var onTimingRecord: ((TimingRecord) -> Void)?` callback property
+  - Wire callback through `ScheduledClickManager`
+
+- [x] Task: Conductor - User Manual Verification 'Timing Data Model & Scheduler Instrumentation' (Protocol in workflow.md)
+
+## Phase 2: Diagnostic Tab UI
+
+- [x] Task (TDD Red): Write snapshot/unit tests for `DiagnosticTabView`
+  - Empty state renders correctly (no firings yet)
+  - Stats section displays min/max/avg/count
+  - Severity badge renders correct color tier
+
+- [x] Task: Implement `DiagnosticTabView`
+  - New file: `Sources/ClickIt/Lite/Views/DiagnosticTabView.swift`
+  - Empty state: message prompting user to run a scheduled click
+  - Stats section: min delta, max delta, avg delta, total firings
+  - Severity badge: color-coded per session's worst/latest severity
+  - Receives `DiagnosticSession` as `@Environment` or injected `@Bindable`
+
+- [x] Task: Conductor - User Manual Verification 'Diagnostic Tab UI' (Protocol in workflow.md)
+
+## Phase 3: Integration into Lite UI
+
+- [x] Task (TDD Red): Write integration test confirming tab appears in Lite UI tab bar
+
+- [x] Task: Add Diagnostic tab to existing Lite `TabView`
+  - Instantiate shared `DiagnosticSession` at the app/scene level
+  - Pass session into `ScheduledClickManager` for wiring to `LiteScheduler`
+  - Add `DiagnosticTabView` as a new tab (e.g. icon: `waveform.path.ecg`)
+  - Exclude new source files from `ClickItLite` target in `Package.swift` if needed
+
+- [x] Task: Conductor - User Manual Verification 'Integration into Lite UI' (Protocol in workflow.md)

--- a/conductor/tracks/timingdiag_20260321/spec.md
+++ b/conductor/tracks/timingdiag_20260321/spec.md
@@ -1,0 +1,59 @@
+# Spec: Lite Scheduler Timing Diagnostic Screen
+
+## Overview
+
+An in-app diagnostic tab within the ClickIt Lite UI that passively observes the
+LiteScheduler and records timing accuracy data each time a real scheduled click
+fires. Gives users and developers a live view of how precisely the scheduler is
+performing against its target fire times.
+
+## Functional Requirements
+
+### Data Captured Per Firing
+- **Scheduled fire time** — the timestamp the click was intended to fire
+- **Actual fire time** — the timestamp the click actually fired (captured inside
+  the execution handler)
+- **Delta** — difference between actual and scheduled (in milliseconds), signed
+  (positive = late, negative = early)
+
+### Statistics (session-scoped, reset on app launch)
+- Minimum delta
+- Maximum delta
+- Average delta
+- Total firings observed
+
+### Visual Accuracy Indicator
+Color-coded severity badge per firing and for the session summary:
+- 🟢 Green — delta ≤ 10ms (within ClickIt's sub-10ms accuracy goal)
+- 🟡 Yellow — delta 10–50ms (degraded)
+- 🔴 Red — delta > 50ms (unacceptable)
+
+### UI Placement
+- Presented as a dedicated **tab** within the existing Lite main UI
+- Tab is always visible; data populates passively as scheduled clicks fire
+- Empty state shown when no firings have been observed yet
+
+### Data Collection
+- Passive only — no test-mode clicks fired
+- Hooks into `LiteScheduler` (or `ScheduledClickManager`) to record timestamps
+  at the moment the execution handler is called
+- Scheduled time is captured at the point the scheduler is armed
+
+## Non-Functional Requirements
+- Zero impact on scheduling accuracy (observation must not add latency)
+- UI updates on the main thread; timing capture on the scheduler's dispatch queue
+- No persistence — data is in-memory, session-scoped only
+
+## Acceptance Criteria
+- [ ] Diagnostic tab is visible in the Lite UI
+- [ ] Each scheduled click firing records scheduled time, actual time, and delta
+- [ ] Session stats (min/max/avg, total count) update after each firing
+- [ ] Color-coded severity badge reflects the correct tier for each delta value
+- [ ] Empty state is shown before any firings occur
+- [ ] Timing capture adds no measurable latency to the scheduler
+
+## Out of Scope
+- Historical log of individual firings (no per-entry list)
+- User-configurable thresholds
+- On-demand test mode / synthetic clicks
+- Persistence across app launches


### PR DESCRIPTION
@Observable let-property, internal computed view props for testing, TabView frame adjustment, directory-level SPM exclude, timing capture order, and LiteScheduler-direct integration test pattern.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>